### PR TITLE
fix old boots for strapping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,10 @@ jobs:
 
 # Before anything else, get the latest versions of things
 before_script:
-  - julia -e 'using Pkg; Pkg.add([PackageSpec(name="BinaryBuilder", rev="master"), PackageSpec(name="BinaryProvider")])'
+  - julia -e 'using Pkg;
+      Pkg.add(PackageSpec(name="MbedTLS", version="0.6.6"));
+      Pkg.pin(PackageSpec(name="MbedTLS", version="0.6.6"));
+      Pkg.add([PackageSpec(name="BinaryBuilder", rev="master"), PackageSpec(name="BinaryProvider")])'
 
 script:
   - julia build_tarballs.jl --part=$PART --verbose


### PR DESCRIPTION
This worked fine for me to get the "Regenerate build.jl" stage to work in GEOSBuilder.
Can be removed again once MbedTLS.jl v0.6.8 is released.